### PR TITLE
Rollback jeet and gulp-jade-php versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-gettext": "0.3.0",
     "gulp-if": "2.0.1",
     "gulp-imagemin": "3.0.1",
-    "gulp-jade-php": "2.0.0-0",
+    "gulp-jade-php": "1.1.0",
     "gulp-clean-css": "2.0.11",
     "gulp-order": "1.1.1",
     "gulp-plumber": "1.1.0",
@@ -32,7 +32,7 @@
     "gulp-unzip": "0.1.4",
     "gulp-wp-pot": "1.2.2",
     "gulp-wrap": "0.13.0",
-    "jeet": "6.1.4",
+    "jeet": "6.1.2",
     "lodash": "4.13.1",
     "nib": "1.1.0",
     "yargs": "4.7.1"


### PR DESCRIPTION
We had some errors with `compileStylesheets` task after updating jeet to 1.6.4 (you can find an old issue about this [here](https://github.com/mojotech/jeet/issues/129)) and some errors in `compileTemplates` after the update of `gulp-jade-php` (that I can't explain) so here's a rollback of the versions of these two packages.
<details>

```
[09:43:55] Plumber found unhandled error:
 Error in plugin 'gulp-stylus'
Message:
    c:\Users\Thomas\git\wordpress-gulp-jade-stylus\themes\lendix-2015\stylesheets\style.styl:5:9
   1| /**
   2|  * Stylus helpers
   3|  */
   4|
   5| @import 'jeet'
--------------^
   6| @import 'nib'
   7|
   8| /**

failed to locate @import file jeet.styl

Details:
    lineno: 5
    column: 9
    filename: c:\Users\Thomas\git\wordpress-gulp-jade-stylus\themes\lendix-2015\stylesheets\style.styl
    stylusStack:
[09:43:55] Finished 'compileStylesheets' after 346 ms
[09:43:56] Plumber found unhandled error:
 TypeError in plugin 'gulp-jade-php'
Message:
    code.replace is not a function

Please report this entire error and stack trace to https://github.com/jadejs/jade/issues
[09:43:56] Finished 'compileFunctions' after 1.33 s
[09:43:56] Finished 'compilePO' after 1.33 s
[09:43:57] Finished 'compileJavascripts' after 1.7 s
[09:43:58] Plumber found unhandled error:
 TypeError in plugin 'gulp-jade-php'
Message:
    str.split is not a function

Please report this entire error and stack trace to https://github.com/jadejs/jade/issues
```

</details>
